### PR TITLE
Correct issue #1 by changing description parsing regex

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -83,7 +83,7 @@ final class Page
             // remove extra newline
             '/:\n/' => ':',
             // color example command usage description
-            '/(- .+)/' => '<info>$1</info>',
+            '/^(- .+)/m' => '<info>$1</info>',
             // remove braces
             '/{{(.+?)}}/' => '$1',
             // color all text in example command usage

--- a/tests/TldrTest.php
+++ b/tests/TldrTest.php
@@ -77,8 +77,9 @@ class TldrTest extends TestCase
 
     /**
      * @test
+     * See: https://github.com/BrainMaestro/tldr-php/issues/1
      */
-    public function it_gets_a_tldr_page_that_has_a_mid_sentence_dash_character()
+    public function it_gets_a_tldr_page_that_has_a_mid_sentence_dash_character_without_failing()
     {
         $this->commandTester->execute(['page' => 'curl']);
 

--- a/tests/TldrTest.php
+++ b/tests/TldrTest.php
@@ -74,4 +74,15 @@ class TldrTest extends TestCase
         $this->assertEmpty($this->commandTester->getDisplay());
         $this->assertNotEquals(0, $this->commandTester->getStatusCode());
     }
+
+    /**
+     * @test
+     */
+    public function it_gets_a_tldr_page_that_has_a_mid_sentence_dash_character()
+    {
+        $this->commandTester->execute(['page' => 'curl']);
+
+        $this->assertNotEmpty($this->commandTester->getDisplay());
+        $this->assertEquals(0, $this->commandTester->getStatusCode());
+    }
 }


### PR DESCRIPTION
Fixes #1 by updating the page description regex to handle `-` characters in mid-sentence.