### PR TITLE
Added an optional $subDir argument to the getCacheDir() method

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -15,7 +15,7 @@ final class Page
      */
     public static function get(string $platform, string $page): string
     {
-        $cacheDir = self::getCacheDir() . '/' . $platform;
+        $cacheDir = self::getCacheDir('/pages') . '/' . $platform;
         $pageFile = "{$cacheDir}/{$page}.md";
 
         if (! is_dir($cacheDir)) {
@@ -56,7 +56,7 @@ final class Page
      */
     public static function update()
     {
-        $cacheDir = self::getCacheDir();
+        $cacheDir = self::getCacheDir('/pages');
 
         if (! is_dir($cacheDir)) {
             return;
@@ -99,8 +99,8 @@ final class Page
         return $content;
     }
 
-    private static function getCacheDir(): string
+    private static function getCacheDir(string $subDir = ''): string
     {
-        return "{$_SERVER['HOME']}/.tldr";
+        return "{$_SERVER['HOME']}/.tldr".$subDir;
     }
 }

--- a/src/Page.php
+++ b/src/Page.php
@@ -15,7 +15,7 @@ final class Page
      */
     public static function get(string $platform, string $page): string
     {
-        $cacheDir = self::getCacheDir('/pages') . '/' . $platform;
+        $cacheDir = self::getCacheDir() . '/' . $platform;
         $pageFile = "{$cacheDir}/{$page}.md";
 
         if (! is_dir($cacheDir)) {
@@ -56,7 +56,7 @@ final class Page
      */
     public static function update()
     {
-        $cacheDir = self::getCacheDir('/pages');
+        $cacheDir = self::getCacheDir();
 
         if (! is_dir($cacheDir)) {
             return;
@@ -99,8 +99,8 @@ final class Page
         return $content;
     }
 
-    private static function getCacheDir(string $subDir = ''): string
+    private static function getCacheDir(): string
     {
-        return "{$_SERVER['HOME']}/.tldr".$subDir;
+        return "{$_SERVER['HOME']}/.tldr/pages";
     }
 }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -12,7 +12,7 @@ class PageTest extends TestCase
      */
     public function it_gets_a_tldr_page_that_does_not_exist_locally_and_saves_it()
     {
-        $path = "{$_SERVER['HOME']}/.tldr/common/tar.md";
+        $path = "{$_SERVER['HOME']}/.tldr/pages/common/tar.md";
         if (file_exists($path)) {
             unlink($path);
         }
@@ -35,7 +35,7 @@ class PageTest extends TestCase
      */
     public function it_deletes_the_entire_local_cache()
     {
-        $path = "{$_SERVER['HOME']}/.tldr/common/tar.md";
+        $path = "{$_SERVER['HOME']}/.tldr/pages/common/tar.md";
         Page::get('common', 'tar');
 
         $this->assertTrue(file_exists($path));


### PR DESCRIPTION
Added an optional `$subDir` argument to the `getCacheDir()` method to allow specifying `/pages`
Fixes #5.