### PR TITLE
Add custom help text when no page is specified

### DIFF
--- a/src/Commands/Tldr.php
+++ b/src/Commands/Tldr.php
@@ -59,7 +59,7 @@ class Tldr extends Command
         }
 
         if (! $page) {
-            $output->writeln("<error>You must provide a command</error>");
+            $output->writeln($this->getHelpText());
             return 1;
         }
 
@@ -71,5 +71,17 @@ class Tldr extends Command
         }
 
         $output->writeln($pageContent);
+    }
+
+    private function getHelpText()
+    {
+        return <<<TXT
+  <info>Usage: tldr command [options]</info>
+    
+  Options:
+    -p, --platform [type]     platform of the command
+    -u, --update              update the local page cache
+    -c, --clear-cache         clear the local page cache
+TXT;
     }
 }

--- a/tests/TldrTest.php
+++ b/tests/TldrTest.php
@@ -9,6 +9,9 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class TldrTest extends TestCase
 {
+    /**
+     * @var CommandTester
+     */
     private $commandTester;
 
     public function setUp()
@@ -47,7 +50,16 @@ class TldrTest extends TestCase
         $this->commandTester->execute([]);
 
         $this->assertNotEmpty($this->commandTester->getDisplay());
-        $this->assertEquals('You must provide a command', trim($this->commandTester->getDisplay()));
+        $this->assertEquals(<<<TXT
+  Usage: tldr command [options]
+    
+  Options:
+    -p, --platform [type]     platform of the command
+    -u, --update              update the local page cache
+    -c, --clear-cache         clear the local page cache
+
+TXT
+            , $this->commandTester->getDisplay());
         $this->assertEquals(1, $this->commandTester->getStatusCode());
     }
 


### PR DESCRIPTION
This change moves the error text into a custom method, and allows easier editing of the help output.

This is more standard across binary files, and implements #9. It may however be nice to add in something to mention that this is `tldr-php` in the message. :thinking:

Closes #9.