### PR TITLE
Add Travis testing for PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: php
 php:
   - '7.0'
   - '7.1'
+  - 7.2
 before_script: composer install

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "symfony/console": "^3.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.2"
+    "phpunit/phpunit": "^6.2 || ^7.0"
   },
   "scripts": {
     "test": "./vendor/bin/phpunit"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>


### PR DESCRIPTION
This also adds support for PHPUnit ^7.0.

One thing I wasn't sure about was whether the lock should be removed. Technically this is a library, and normally locks aren't included with libraries so as to be kept on the latest supported versions of dependencies. Up to you though :+1: