### PR TITLE
Add support for PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 php:
-  - '7.0'
-  - '7.1'
+  - 7.0
+  - 7.1
   - 7.2
+  - 7.3
 before_script: composer install

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require": {
     "php": "^7.1",
-    "symfony/console": "^3.3"
+    "symfony/console": "^4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.2 || ^7.0"

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     }
   },
   "require": {
+    "php": "^7.1",
     "symfony/console": "^3.3"
   },
   "require-dev": {


### PR DESCRIPTION
This also:
- Removes support for PHP `<7.1` which no longer has security support
- Updates to Symfony Console `^4.0`