### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -4,7 +4,7 @@ namespace BrainMaestro\Tldr;
 
 final class Page
 {
-    const BASE_URL = 'https://raw.githubusercontent.com/tldr-pages/tldr/master/pages/';
+    const BASE_URL = 'https://raw.githubusercontent.com/tldr-pages/tldr/main/pages/';
 
     /**
      * Get the page for the platform in the local cache or download it if it does not exist


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the `master` branch in favor of the `main` branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).